### PR TITLE
Add Firefox xpi link (self deployed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ Prerequisites:
 1. If you have a new UI, make sure to "Revert to old version" by clicking on your profile icon, there should be an option to do so there.
 2. Only have **one** leetcode tab open.
 
-## Instructions
 Getting Started:
 1. Download the **[Bogosearch - LeetCode Rooms](https://chrome.google.com/webstore/detail/bogosearch-leetcode-rooms/elcfbhjmhecbkfilbohmojhoiidpokjf?hl=en-US)** extension, make sure that it is the latest version for a dope experience.
-  1. Firefox users please use this link: [Bogosearch - LeetCode Rooms](https://addons.mozilla.org/firefox/downloads/file/4029221/e154b51d94504d7098aa-0.4.1.xpi)
+    1. Firefox users please use this link: [Bogosearch - LeetCode Rooms](https://addons.mozilla.org/firefox/downloads/file/4029221/e154b51d94504d7098aa-0.4.1.xpi)
 2. Reload your leetcode page.
 3. Join or create a room.
 4. Invite friends!

--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@ Check out https://github.com/sunnyguan/leetcode-rooms-chrome-extension for more 
 
 # Latest Version: 0.4.1
 
-# Instructions:
+## Instructions:
 Prerequisites:
 1. If you have a new UI, make sure to "Revert to old version" by clicking on your profile icon, there should be an option to do so there.
 2. Only have **one** leetcode tab open.
 
+## Instructions
 Getting Started:
 1. Download the **[Bogosearch - LeetCode Rooms](https://chrome.google.com/webstore/detail/bogosearch-leetcode-rooms/elcfbhjmhecbkfilbohmojhoiidpokjf?hl=en-US)** extension, make sure that it is the latest version for a dope experience.
+  1. Firefox users please use this link: [Bogosearch - LeetCode Rooms](https://addons.mozilla.org/firefox/downloads/file/4029221/e154b51d94504d7098aa-0.4.1.xpi)
 2. Reload your leetcode page.
 3. Join or create a room.
 4. Invite friends!


### PR DESCRIPTION
Firefox doesn't support Manifest Version 3 in official release yet, so I've downgraded to MV2 for the Firefox specific version and signed it on the Firefox developer dashboard. Updated README to include the link. 